### PR TITLE
sync light calibration is almost done.

### DIFF
--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -915,11 +915,11 @@ static inline void state_opt_calibrating(void) {
 
     // this line only used for enable LC
     radio_txEnable();
-    int8_t ticks = 1000;
+    // int8_t ticks = 1000;
     while (1) {
-        while (ticks) {
-            ticks--;
-        };
+        // while (ticks) {
+        //     ticks--;
+        // };
         decode_lighthouse();
     }
 }

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -710,13 +710,7 @@ void decode_lighthouse(void) {
                                 // once the count_sync_light == 0,will reset
                                 // clock counters in rising edge
                                 sync_cal.count_sync_light = 0;
-                                sync_cal.several_synclights_duration =
-                                    lighthouse_ptc.t_0_start -
-                                    sync_cal.several_synclights_start;
-                                // also, the last time LC counter need be
-                                // recorded
-                                sync_cal_registers.last_sync_LC_start =
-                                    sync_cal_registers.count_LC;
+
                                 // gpio_8_toggle();  // debug,remove later
                                 // // after save last LC value, we need reset
                                 // the
@@ -743,6 +737,7 @@ void decode_lighthouse(void) {
                                 // print LC value to test if we get a right LC
                                 // in 10 synclight periods printf("LC div:
                                 // %u\n", sync_cal_registers.count_LC);
+
                                 printf("2m: %u, lc: %u, 32k: %u, Hf: %u\r\n",
                                        sync_cal_registers.count_2M,
                                        sync_cal_registers.count_LC,
@@ -926,15 +921,15 @@ static inline void state_opt_calibrating(void) {
     gpio_ext8_state = SYNC_LIGHT_ISR;
     // optical_enableLCCalibration();
 
-    // does not worked,why?
-    synclight_cal_enableLCCalibration();
-
-    // For TX, LC target freq = 2.402G - 0.25M = 2.40175 GHz.
-    // optical_setLCTarget(250182);
-    synclight_cal_setLCTarget(250182);
     config_lighthouse_mote();
-    // use inline function, this time should work.
+    // use inline function, this time should work. remember this should after
+    // config_lighthouse_mote.
     synclight_cal_enable_LC_calibration();
+
+    // For TX, LC target freq = 2.402G - 0.25M = 2.40175 GHz.Then divide by
+    // 960 to get the target LC value.But here we use 250580 for sync light
+    // calibration.
+    synclight_cal_setLCTarget(250580);
 
     // this line only used for enable LC
     radio_txEnable();

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -514,18 +514,6 @@ void decode_lighthouse(void) {
         // Save when this event happened
         lighthouse_ptc.timestamp_rise = RFTIMER_REG__COUNTER;
 
-        // uint32_t rdata_lsb, rdata_msb;
-        // uint32_t count_LC;
-        // uint32_t first_sync_LC_start, last_sync_LC_start;
-
-        // uint32_t count_32k, count_2M, count_HFclock, count_IF;
-        // // a new LC_diff to replace the struct variable one
-        // // (synclight_cal_vars.cal_LC_diff).
-        // int32_t real_LC_diff;
-
-        // int32_t tmp_countLC, tmp_LC_target;
-        // uint8_t flag_reset_counter, flag_save_counter_value;
-
         // read counters, but first we have to know whether reset the counters
         // to zero or not by flag_reset_counter
         if (sync_cal_registers.flag_reset_counter == 1) {
@@ -573,34 +561,21 @@ void decode_lighthouse(void) {
         sync_cal_registers.count_32k =
             sync_cal_registers.rdata_lsb + (sync_cal_registers.rdata_msb << 16);
 
+        // only for debugging,should toggle before uart send , uart latency is
+        // large
+        gpio_10_toggle();
         // printf("LC div: %u\n", sync_cal_registers.count_LC);
         printf("2m: %u, lc: %u, 32k: %u, Hf: %u\r\n",
                sync_cal_registers.count_2M, sync_cal_registers.count_LC,
                sync_cal_registers.count_32k, sync_cal_registers.count_HFclock);
-
-        // // Read 2M counter
-        // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x180000);
-        // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x1C0000);
-        // count_2M = rdata_lsb + (rdata_msb << 16);
-
-        // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x280000);
-        // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x2C0000);
-        // count_LC = rdata_lsb + (rdata_msb << 16);
-
-        // // Read 32k counter
-        // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x000000);
-        // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x040000);
-        // count_32k = rdata_lsb + (rdata_msb << 16);
-
-        // printf("2m: %u, lc: %u, 32k %u\r\n", count_2M, count_LC, count_32k);
+        // set the CFG_REG to config counters
         // Reset all counters
         ANALOG_CFG_REG__0 = 0x0000;
-
         // Enable all counters
         ANALOG_CFG_REG__0 = 0x3FFF;
 
-        //      only for debugging
-        gpio_10_toggle();
+        // //      only for debugging
+        // gpio_10_toggle();
         switch (lighthouse_ptc.flag_start) {
             case 0:
                 lighthouse_ptc.t_0_start = lighthouse_ptc.timestamp_rise;

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -689,21 +689,16 @@ void decode_lighthouse(void) {
                         // }
 
                         // 如果不在有效计数周期内且检测到同步光，开始新的计数周期
-                        if (!sync_cal.in_valid_counting_period) {
-                            sync_cal.in_valid_counting_period = true;
-                            sync_cal.count_sync_light = 0;  // 确保从0开始计数
-                            // 下一个上升沿会重置计数器
-                        }
 
                         if (sync_cal.in_valid_counting_period) {
-                            sync_cal.count_sync_light++;
+                            sync_cal.count_sync_light += 1;
 
                             // when the count turn to 12, it is a sync
                             // calibration period.
                             if ((sync_cal.count_sync_light == 12) &&
                                 (sync_cal.need_sync_calibration == 1)) {
                                 // 结束当前计数周期
-                                sync_cal.in_valid_counting_period = true;
+                                sync_cal.in_valid_counting_period = false;
                                 // once the count_sync_light == 0,will reset
                                 // clock counters in rising edge
                                 sync_cal.count_sync_light = 0;
@@ -748,6 +743,10 @@ void decode_lighthouse(void) {
 
                                 sync_cal.count_calibration += 1;
                             }
+                        } else {
+                            sync_cal.in_valid_counting_period = true;
+                            sync_cal.count_sync_light = 0;  // 确保从0开始计数
+                            // 下一个上升沿会重置计数器
                         }
                         break;
                     case sweep_light:

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -695,7 +695,7 @@ void decode_lighthouse(void) {
 
                             // when the count turn to 12, it is a sync
                             // calibration period.
-                            if ((sync_cal.count_sync_light == 12) &&
+                            if ((sync_cal.count_sync_light == 13) &&
                                 (sync_cal.need_sync_calibration == 1)) {
                                 // 结束当前计数周期
                                 sync_cal.in_valid_counting_period = false;

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -567,6 +567,14 @@ void decode_lighthouse(void) {
         sync_cal_registers.count_32k =
             sync_cal_registers.rdata_lsb + (sync_cal_registers.rdata_msb << 16);
 
+        // Read IF ADC_CLK counter
+        sync_cal_registers.rdata_lsb =
+            *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x300000);
+        sync_cal_registers.rdata_msb =
+            *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x340000);
+        sync_cal_registers.count_IF =
+            sync_cal_registers.rdata_lsb + (sync_cal_registers.rdata_msb << 16);
+
         // only for debugging,should toggle before uart send , uart latency is
         // large
         gpio_10_toggle();
@@ -742,6 +750,12 @@ void decode_lighthouse(void) {
                                        sync_cal_registers.count_HFclock);
 
                                 sync_cal.count_calibration += 1;
+
+                                sync_light_calibrate_all_clocks(
+                                    sync_cal_registers.count_HFclock,
+                                    sync_cal_registers.count_2M,
+                                    sync_cal_registers.count_IF,
+                                    sync_cal_registers.count_LC);
                             }
                         } else {
                             sync_cal.in_valid_counting_period = true;

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -908,6 +908,13 @@ static inline void synclight_cal_enable_LC_calibration(void) {
     synclight_cal_vars.cal_LC_fine = LC_CAL_FINE_MIN;
     synclight_cal_vars.optical_LC_cal_enable = true;
     synclight_cal_vars.optical_LC_cal_finished = false;
+    printf(
+        "Debug: LC cal enabled, coarse=%d, mid=%d, fine=%d, enable=%d, "
+        "finished=%d\r\n",
+        synclight_cal_vars.cal_LC_coarse, synclight_cal_vars.cal_LC_mid,
+        synclight_cal_vars.cal_LC_fine,
+        synclight_cal_vars.optical_LC_cal_enable,
+        synclight_cal_vars.optical_LC_cal_finished);
     LC_FREQCHANGE(synclight_cal_vars.cal_LC_coarse,
                   synclight_cal_vars.cal_LC_mid,
                   synclight_cal_vars.cal_LC_fine);
@@ -926,6 +933,8 @@ static inline void state_opt_calibrating(void) {
     // optical_setLCTarget(250182);
     synclight_cal_setLCTarget(250182);
     config_lighthouse_mote();
+    // use inline function, this time should work.
+    synclight_cal_enable_LC_calibration();
 
     // this line only used for enable LC
     radio_txEnable();

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -640,8 +640,10 @@ void decode_lighthouse(void) {
                     lighthouse_ptc.t_0_end - lighthouse_ptc.t_0_start;
                 // Dividing the two signals by 50us: 0.000,050/(1/10M) = 500
                 // = 0x320,99us(990ticks) for skip/sync
+                // usually soft read time is 10+us shorter than hw read time
+                // so I set the boundary condition to 300us()
                 (lighthouse_ptc.t_opt_pulse <
-                 500)  // actual boundary condition maybe a little different
+                 300)  // actual boundary condition maybe a little different
                     ? (lighthouse_ptc.flag_light_type = sweep_light)
                     : ((lighthouse_ptc.t_opt_pulse < 990)
                            ? (lighthouse_ptc.flag_light_type = sync_light)
@@ -746,11 +748,14 @@ void decode_lighthouse(void) {
 
                                 sync_cal.count_calibration += 1;
 
-                                sync_light_calibrate_all_clocks(
-                                    sync_cal_registers.count_HFclock,
-                                    sync_cal_registers.count_2M,
-                                    sync_cal_registers.count_IF,
-                                    sync_cal_registers.count_LC);
+                                if (!synclight_cal_vars
+                                         .optical_LC_cal_finished) {
+                                    sync_light_calibrate_all_clocks(
+                                        sync_cal_registers.count_HFclock,
+                                        sync_cal_registers.count_2M,
+                                        sync_cal_registers.count_IF,
+                                        sync_cal_registers.count_LC);
+                                }
                             }
                         } else {
                             sync_cal.in_valid_counting_period = true;

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -915,11 +915,14 @@ static inline void state_opt_calibrating(void) {
 
     // this line only used for enable LC
     radio_txEnable();
-    // int8_t ticks = 1000;
+    //  control delay time.
+    int8_t ticks = 1000;
     while (1) {
-        // while (ticks) {
-        //     ticks--;
-        // };
+        // a little delay for debug, can be removed.
+        while (ticks) {
+            ticks--;
+        };
+        // keep read lighthouse to get light.
         decode_lighthouse();
     }
 }

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -460,7 +460,7 @@ void config_ble_tx_mote(void) {
     //--------------------------------------------------------
 };
 // a method used to replace old xy distinguish method from kilberg code.
-#define WIDTH_BIAS (0 - 0)
+#define WIDTH_BIAS (-100)
 void distinguish_xy(uint32_t light_duration) {
     // Identify what kind of pulse this was
 
@@ -641,9 +641,12 @@ void decode_lighthouse(void) {
                 // Dividing the two signals by 50us: 0.000,050/(1/10M) = 500
                 // = 0x320,99us(990ticks) for skip/sync
                 // usually soft read time is 10+us shorter than hw read time
-                // so I set the boundary condition to 300us()
+                // so I set the boundary condition to 320ticks(). Ofcourse,
+                // it is not accurate, we need to adjust it  300-500ticks
+                // to get the best result. Remember to change it when temperature
+                // changes.
                 (lighthouse_ptc.t_opt_pulse <
-                 300)  // actual boundary condition maybe a little different
+                 320)  // actual boundary condition maybe a little different
                     ? (lighthouse_ptc.flag_light_type = sweep_light)
                     : ((lighthouse_ptc.t_opt_pulse < 990)
                            ? (lighthouse_ptc.flag_light_type = sync_light)
@@ -740,12 +743,6 @@ void decode_lighthouse(void) {
                                 // in 10 synclight periods printf("LC div:
                                 // %u\n", sync_cal_registers.count_LC);
 
-                                printf("2m: %u, lc: %u, 32k: %u, Hf: %u\r\n",
-                                       sync_cal_registers.count_2M,
-                                       sync_cal_registers.count_LC,
-                                       sync_cal_registers.count_32k,
-                                       sync_cal_registers.count_HFclock);
-
                                 sync_cal.count_calibration += 1;
 
                                 if (!synclight_cal_vars
@@ -755,6 +752,13 @@ void decode_lighthouse(void) {
                                         sync_cal_registers.count_2M,
                                         sync_cal_registers.count_IF,
                                         sync_cal_registers.count_LC);
+                                } else {
+                                    printf(
+                                        "2m: %u, lc: %u, 32k: %u, Hf: %u\r\n",
+                                        sync_cal_registers.count_2M,
+                                        sync_cal_registers.count_LC,
+                                        sync_cal_registers.count_32k,
+                                        sync_cal_registers.count_HFclock);
                                 }
                             }
                         } else {
@@ -932,9 +936,9 @@ static inline void state_opt_calibrating(void) {
     synclight_cal_enable_LC_calibration();
 
     // For TX, LC target freq = 2.402G - 0.25M = 2.40175 GHz.Then divide by
-    // 960 to get the target LC value.But here we use 250580 for sync light
+    // 960 to get the target LC value.But here we use 250370 for sync light
     // calibration.
-    synclight_cal_setLCTarget(250580);
+    synclight_cal_setLCTarget(250370);
 
     // this line only used for enable LC
     radio_txEnable();

--- a/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
+++ b/scm_v3c/applications/synclight_carlibration/synclight_calibration.c
@@ -526,6 +526,7 @@ void decode_lighthouse(void) {
             ANALOG_CFG_REG__0 = 0x0000;
             // Enable all counters
             ANALOG_CFG_REG__0 = 0x3FFF;
+            gpio_8_toggle();  // debug,remove later
         } else {
             // Enable all counters
             ANALOG_CFG_REG__0 = 0x3FFF;
@@ -677,18 +678,19 @@ void decode_lighthouse(void) {
                         // after a sync, the count_sync_light will increase 1,
                         // so when the count_sync_light = 1, it means this is
                         // the first sync light. record start time.
-                        if (sync_cal.count_sync_light == 1) {
-                            sync_cal.several_synclights_start =
-                                lighthouse_ptc.t_0_start;
-                            // also need record first synclight LC counter value
-                            sync_cal_registers.first_sync_LC_start =
-                                sync_cal_registers.count_LC;
-                            // start record 10 sync, donot reset the counter
-                            sync_cal_registers.flag_reset_counter = 0;
-                        }
-                        // when the count turn to 10, it is a sync calibration
+                        // if (sync_cal.count_sync_light == 1) {
+                        //     sync_cal.several_synclights_start =
+                        //         lighthouse_ptc.t_0_start;
+                        //     // also need record first synclight LC counter value
+                        //     sync_cal_registers.first_sync_LC_start =
+                        //         sync_cal_registers.count_LC;
+                        //     // start record 10 sync, donot reset the counter
+                        //     sync_cal_registers.flag_reset_counter = 0;
+                        // }
+
+                        // when the count turn to 12, it is a sync calibration
                         // period.
-                        if ((sync_cal.count_sync_light == 10) &&
+                        if ((sync_cal.count_sync_light == 12) &&
                             (sync_cal.need_sync_calibration == 1)) {
                             // once the count_sync_light == 0,will reset clock
                             // counters in rising edge
@@ -699,7 +701,7 @@ void decode_lighthouse(void) {
                             // also, the last time LC counter need be recorded
                             sync_cal_registers.last_sync_LC_start =
                                 sync_cal_registers.count_LC;
-                            gpio_8_toggle();  // debug,remove later
+                            // gpio_8_toggle();  // debug,remove later
                             // // after save last LC value, we need reset the
                             // // counter to prepare next calibration process
                             // sync_cal_registers.flag_reset_counter = 1;
@@ -721,10 +723,12 @@ void decode_lighthouse(void) {
 
                             // print LC value to test if we get a right LC in 10
                             // synclight periods
-                            printf("LC div: %u\n", sync_cal_registers.count_LC);
-                            // printf("LC div start: %u, end: %u\n",
-                            //        sync_cal_registers.first_sync_LC_start,
-                            //        sync_cal_registers.last_sync_LC_start);
+                            // printf("LC div: %u\n", sync_cal_registers.count_LC);
+                            printf("2m: %u, lc: %u, 32k: %u, Hf: %u\r\n",
+                                   sync_cal_registers.count_2M,
+                                   sync_cal_registers.count_LC,
+                                   sync_cal_registers.count_32k,
+                                   sync_cal_registers.count_HFclock);
 
                             sync_cal.count_calibration += 1;
                         }

--- a/scm_v3c/calibrate_interrupt.c
+++ b/scm_v3c/calibrate_interrupt.c
@@ -464,31 +464,6 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
     // Keep track of how many calibration iterations have been completed
     synclight_cal_vars.optical_cal_iteration++;
 
-    // // Read 32k counter
-    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x000000);
-    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x040000);
-    // count_32k = rdata_lsb + (rdata_msb << 16);
-
-    // // Read HF_CLOCK counter
-    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x100000);
-    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x140000);
-    // count_HFclock = rdata_lsb + (rdata_msb << 16);
-
-    // // Read 2M counter
-    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x180000);
-    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x1C0000);
-    // count_2M = rdata_lsb + (rdata_msb << 16);
-
-    // // Read LC_div counter (via counter4)
-    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x280000);
-    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x2C0000);
-    // count_LC = rdata_lsb + (rdata_msb << 16);
-
-    // // Read IF ADC_CLK counter
-    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x300000);
-    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x340000);
-    // count_IF = rdata_lsb + (rdata_msb << 16);
-
     printf("run in sync cal\r\n");
 
     // Don't make updates on the first two executions of this ISR
@@ -537,30 +512,6 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
         if (synclight_cal_vars.optical_LC_cal_enable &&
             (!synclight_cal_vars.optical_LC_cal_finished)) {
 
-            // This if function just calculate the cal_LC_diff, then give
-            // coarse/mid/fine, since I am already get the real_LC_diff, I just
-            // give new parameters(coarse/mid/fine)
-            // if ((count_LC <= synclight_cal_vars.LC_target) &&
-            //     (synclight_cal_vars.LC_target - count_LC <
-            //      synclight_cal_vars.cal_LC_diff)) {
-            //     printf("condition 1\r\n");
-            //     synclight_cal_vars.cal_LC_diff =
-            //         synclight_cal_vars.LC_target - count_LC;
-            //     synclight_cal_vars.LC_coarse =
-            //     synclight_cal_vars.cal_LC_coarse; synclight_cal_vars.LC_mid =
-            //     synclight_cal_vars.cal_LC_mid; synclight_cal_vars.LC_fine =
-            //     synclight_cal_vars.cal_LC_fine;
-            // } else if ((count_LC > synclight_cal_vars.LC_target) &&
-            //            (count_LC - synclight_cal_vars.LC_target <
-            //             synclight_cal_vars.cal_LC_diff)) {
-            //     printf("condition 2\r\n");
-            //     synclight_cal_vars.cal_LC_diff =
-            //         count_LC - synclight_cal_vars.LC_target;
-            //     synclight_cal_vars.LC_coarse =
-            //     synclight_cal_vars.cal_LC_coarse; synclight_cal_vars.LC_mid =
-            //     synclight_cal_vars.cal_LC_mid; synclight_cal_vars.LC_fine =
-            //     synclight_cal_vars.cal_LC_fine;
-            // }
             synclight_cal_vars.LC_coarse = synclight_cal_vars.cal_LC_coarse;
             synclight_cal_vars.LC_mid = synclight_cal_vars.cal_LC_mid;
             synclight_cal_vars.LC_fine = synclight_cal_vars.cal_LC_fine;
@@ -677,7 +628,7 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
         (!synclight_cal_vars.optical_LC_cal_enable ||
          synclight_cal_vars.optical_LC_cal_finished)) {
         // Disable this ISR
-        ICER = 0x1800;
+        // ICER = 0x1800;
         synclight_cal_vars.optical_cal_iteration = 0;
         synclight_cal_vars.optical_cal_finished = 1;
 
@@ -704,7 +655,7 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
         // radio_disable_all();
 
         // Halt all counters
-        ANALOG_CFG_REG__0 = 0x0000;
+        // ANALOG_CFG_REG__0 = 0x0000;
     }
 }
 // this function use to test call calibration frenquency, so just some print.

--- a/scm_v3c/calibrate_interrupt.c
+++ b/scm_v3c/calibrate_interrupt.c
@@ -437,13 +437,9 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
     // 1.1V/VDDD tap fix
     // helps reorder assembly code
     // Not completely sure why this works
-    //    uint32_t dummy = 0;
 
-    //    int32_t t;
-    uint32_t rdata_lsb, rdata_msb;
     uint32_t count_32k;
-    // a new LC_diff to replace the struct variable one
-    // (synclight_cal_vars.cal_LC_diff).
+
     int32_t real_LC_diff;
     uint32_t HF_CLOCK_fine;
     uint32_t HF_CLOCK_coarse;
@@ -531,15 +527,16 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
                            ? (tmp_countLC - tmp_LC_target)
                            : (tmp_LC_target - tmp_countLC);
 
+        synclight_cal_vars.optical_LC_cal_enable = 1;  // just test
+
         //    disable it to reduce time cost
-        // printf("condition in %u, %u, diff:%u\r\n",
-        //        synclight_cal_vars.optical_LC_cal_enable,
-        //        synclight_cal_vars.optical_LC_cal_finished, real_LC_diff);
+        printf("condition in %u, %u, diff:%u\r\n",
+               synclight_cal_vars.optical_LC_cal_enable,
+               synclight_cal_vars.optical_LC_cal_finished, real_LC_diff);
 
         if (synclight_cal_vars.optical_LC_cal_enable &&
             (!synclight_cal_vars.optical_LC_cal_finished)) {
-            // printf("condition in %u,
-            // %u",nclight_cal_vars.optical_LC_cal_enable,synclight_cal_vars.optical_LC_cal_finished);
+
             // This if function just calculate the cal_LC_diff, then give
             // coarse/mid/fine, since I am already get the real_LC_diff, I just
             // give new parameters(coarse/mid/fine)

--- a/scm_v3c/calibrate_interrupt.c
+++ b/scm_v3c/calibrate_interrupt.c
@@ -423,6 +423,300 @@ void sync_light_calibrate_isr(void) {
         ANALOG_CFG_REG__0 = 0x0000;
     }
 }
+
+void sync_light_calibrate_isr_individual_LC(uint32_t LC_start, uint32_t LC_end) {
+    //	gpio_10_toggle();
+
+    // This interrupt goes off when the optical register holds the value {221,
+    // 176,
+    // 231, 47} This interrupt can also be used to synchronize to the start of
+    // an optical data transfer Need to make sure a new bit has been clocked in
+    // prior to returning from this ISR, or else it will immediately execute
+    // again
+    // 1.1V/VDDD tap fix
+    // helps reorder assembly code
+    // Not completely sure why this works
+    //    uint32_t dummy = 0;
+
+    //    int32_t t;
+    uint32_t rdata_lsb, rdata_msb;
+    int32_t count_LC;
+    uint32_t count_32k, count_2M, count_HFclock, count_IF;
+    // a new LC_diff to replace the struct variable one
+    // (synclight_cal_vars.cal_LC_diff).
+    int32_t real_LC_diff;
+    uint32_t HF_CLOCK_fine;
+    uint32_t HF_CLOCK_coarse;
+    uint32_t RC2M_coarse;
+    uint32_t RC2M_fine;
+    uint32_t RC2M_superfine;
+    //    uint32_t IF_clk_target;
+    uint32_t IF_coarse;
+    uint32_t IF_fine;
+
+    int32_t tmp_countLC, tmp_LC_target;
+
+    HF_CLOCK_fine = scm3c_hw_interface_get_HF_CLOCK_fine();
+    HF_CLOCK_coarse = scm3c_hw_interface_get_HF_CLOCK_coarse();
+    RC2M_coarse = scm3c_hw_interface_get_RC2M_coarse();
+    RC2M_fine = scm3c_hw_interface_get_RC2M_fine();
+    RC2M_superfine = scm3c_hw_interface_get_RC2M_superfine();
+    //    IF_clk_target = scm3c_hw_interface_get_IF_clk_target();
+    IF_coarse = scm3c_hw_interface_get_IF_coarse();
+    IF_fine = scm3c_hw_interface_get_IF_fine();
+
+    // Disable all counters
+    ANALOG_CFG_REG__0 = 0x007F;
+
+    // Keep track of how many calibration iterations have been completed
+    synclight_cal_vars.optical_cal_iteration++;
+
+    // Read 32k counter
+    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x000000);
+    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x040000);
+    count_32k = rdata_lsb + (rdata_msb << 16);
+
+    // Read HF_CLOCK counter
+    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x100000);
+    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x140000);
+    count_HFclock = rdata_lsb + (rdata_msb << 16);
+
+    // Read 2M counter
+    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x180000);
+    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x1C0000);
+    count_2M = rdata_lsb + (rdata_msb << 16);
+
+    // Read LC_div counter (via counter4)
+    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x280000);
+    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x2C0000);
+    count_LC = rdata_lsb + (rdata_msb << 16);
+
+    // Read IF ADC_CLK counter
+    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x300000);
+    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x340000);
+    count_IF = rdata_lsb + (rdata_msb << 16);
+
+    // Reset all counters
+    ANALOG_CFG_REG__0 = 0x0000;
+
+    // Enable all counters
+    ANALOG_CFG_REG__0 = 0x3FFF;
+
+    // Don't make updates on the first two executions of this ISR
+    if (synclight_cal_vars.optical_cal_iteration > 2) {
+        // Do correction on HF CLOCK
+        // Fine DAC step size is about 6000 counts
+        if (count_HFclock < 1997000) {  // 1997000 original value
+            if (HF_CLOCK_fine == 0) {
+                HF_CLOCK_coarse--;
+                HF_CLOCK_fine = 10;
+                synclight_cal_vars.optical_cal_iteration = 3;
+            } else {
+                HF_CLOCK_fine--;
+            }
+        }
+        if (count_HFclock > 2003000) {  // new value I picked was
+                                        // 2010000, originally 2003000
+            if (HF_CLOCK_fine == 31) {
+                HF_CLOCK_coarse++;
+                HF_CLOCK_fine = 20;
+                synclight_cal_vars.optical_cal_iteration = 3;
+            } else {
+                HF_CLOCK_fine++;
+            }
+        }
+
+        set_sys_clk_secondary_freq(HF_CLOCK_coarse, HF_CLOCK_fine);
+        scm3c_hw_interface_set_HF_CLOCK_coarse(HF_CLOCK_coarse);
+        scm3c_hw_interface_set_HF_CLOCK_fine(HF_CLOCK_fine);
+
+        // Do correction on LC
+        // debugging, why diff cannot be calculated?
+        tmp_countLC = count_LC;
+        tmp_LC_target = synclight_cal_vars.LC_target;
+        real_LC_diff = (tmp_countLC > tmp_LC_target)
+                           ? (tmp_countLC - tmp_LC_target)
+                           : (tmp_LC_target - tmp_countLC);
+
+        //    disable it to reduce time cost
+        // printf("condition in %u, %u, diff:%u\r\n",
+        //        synclight_cal_vars.optical_LC_cal_enable,
+        //        synclight_cal_vars.optical_LC_cal_finished, real_LC_diff);
+
+        if (synclight_cal_vars.optical_LC_cal_enable &&
+            (!synclight_cal_vars.optical_LC_cal_finished)) {
+            // printf("condition in %u,
+            // %u",nclight_cal_vars.optical_LC_cal_enable,synclight_cal_vars.optical_LC_cal_finished);
+            // This if function just calculate the cal_LC_diff, then give
+            // coarse/mid/fine, since I am already get the real_LC_diff, I just
+            // give new parameters(coarse/mid/fine)
+            // if ((count_LC <= synclight_cal_vars.LC_target) &&
+            //     (synclight_cal_vars.LC_target - count_LC <
+            //      synclight_cal_vars.cal_LC_diff)) {
+            //     printf("condition 1\r\n");
+            //     synclight_cal_vars.cal_LC_diff =
+            //         synclight_cal_vars.LC_target - count_LC;
+            //     synclight_cal_vars.LC_coarse =
+            //     synclight_cal_vars.cal_LC_coarse; synclight_cal_vars.LC_mid =
+            //     synclight_cal_vars.cal_LC_mid; synclight_cal_vars.LC_fine =
+            //     synclight_cal_vars.cal_LC_fine;
+            // } else if ((count_LC > synclight_cal_vars.LC_target) &&
+            //            (count_LC - synclight_cal_vars.LC_target <
+            //             synclight_cal_vars.cal_LC_diff)) {
+            //     printf("condition 2\r\n");
+            //     synclight_cal_vars.cal_LC_diff =
+            //         count_LC - synclight_cal_vars.LC_target;
+            //     synclight_cal_vars.LC_coarse =
+            //     synclight_cal_vars.cal_LC_coarse; synclight_cal_vars.LC_mid =
+            //     synclight_cal_vars.cal_LC_mid; synclight_cal_vars.LC_fine =
+            //     synclight_cal_vars.cal_LC_fine;
+            // }
+            synclight_cal_vars.LC_coarse = synclight_cal_vars.cal_LC_coarse;
+            synclight_cal_vars.LC_mid = synclight_cal_vars.cal_LC_mid;
+            synclight_cal_vars.LC_fine = synclight_cal_vars.cal_LC_fine;
+
+            printf("count_LC: %u, LC_target: %u, LC_diff: %u\r\n", count_LC,
+                   synclight_cal_vars.LC_target, real_LC_diff);
+
+            // By moving this print, time cost 133-125ms, but I need this
+            // info...so reduce synclight count to 7
+            printf("coarse: %u, mid: %u, fine: %u\n",
+                   synclight_cal_vars.LC_coarse, synclight_cal_vars.LC_mid,
+                   synclight_cal_vars.LC_fine);
+            // why the stop codition is not related to LC_diff? I find
+            // that the mid is correct enought when LC_diff is smaller
+            // than 100.
+            if (real_LC_diff < MIN_LC_DIFF) {
+                synclight_cal_vars.optical_LC_cal_finished = true;
+            } else {
+                ++synclight_cal_vars.cal_LC_fine;
+                if (synclight_cal_vars.cal_LC_fine > LC_CAL_FINE_MAX) {
+                    synclight_cal_vars.cal_LC_fine = LC_CAL_FINE_MIN;
+                    ++synclight_cal_vars.cal_LC_mid;
+                    if (synclight_cal_vars.cal_LC_mid > LC_CAL_MID_MAX) {
+                        synclight_cal_vars.cal_LC_mid = LC_CAL_MID_MIN;
+                        ++synclight_cal_vars.cal_LC_coarse;
+                        // why the stop codition is not related to
+                        // LC_diff?
+                        if ((synclight_cal_vars.cal_LC_coarse >
+                             LC_CAL_COARSE_MAX) ||
+                            (real_LC_diff < 100)) {
+                            synclight_cal_vars.optical_LC_cal_finished = true;
+                            printf("coarse: %u, mid: %u, fine: %u\n",
+                                   synclight_cal_vars.LC_coarse,
+                                   synclight_cal_vars.LC_mid,
+                                   synclight_cal_vars.LC_fine);
+                        }
+                    }
+                }
+            }
+
+            if (!synclight_cal_vars.optical_LC_cal_finished) {
+                LC_FREQCHANGE(synclight_cal_vars.cal_LC_coarse,
+                              synclight_cal_vars.cal_LC_mid,
+                              synclight_cal_vars.cal_LC_fine);
+            } else {
+                LC_FREQCHANGE(synclight_cal_vars.LC_coarse,
+                              synclight_cal_vars.LC_mid,
+                              synclight_cal_vars.LC_fine);
+            }
+        }
+
+        // Do correction on 2M RC
+        // Coarse step ~1100 counts, fine ~150 counts, superfine ~25
+        // Too fast
+        if (count_2M > (200600)) {
+            RC2M_coarse += 1;
+        } else {
+            if (count_2M > (200080)) {
+                RC2M_fine += 1;
+            } else {
+                if (count_2M > (200015)) {
+                    RC2M_superfine += 1;
+                }
+            }
+        }
+
+        // Too slow
+        if (count_2M < (199400)) {
+            RC2M_coarse -= 1;
+        } else {
+            if (count_2M < (199920)) {
+                RC2M_fine -= 1;
+            } else {
+                if (count_2M < (199985)) {
+                    RC2M_superfine -= 1;
+                }
+            }
+        }
+
+        set_2M_RC_frequency(31, 31, RC2M_coarse, RC2M_fine, RC2M_superfine);
+        scm3c_hw_interface_set_RC2M_coarse(RC2M_coarse);
+        scm3c_hw_interface_set_RC2M_fine(RC2M_fine);
+        scm3c_hw_interface_set_RC2M_superfine(RC2M_superfine);
+
+        // Do correction on IF RC clock
+        // Fine DAC step size is ~2800 counts
+        if (count_IF > (1600000 + 1400)) {
+            IF_fine += 1;
+        }
+        if (count_IF < (1600000 - 1400)) {
+            IF_fine -= 1;
+        }
+
+        set_IF_clock_frequency(IF_coarse, IF_fine, 0);
+        scm3c_hw_interface_set_IF_coarse(IF_coarse);
+        scm3c_hw_interface_set_IF_fine(IF_fine);
+
+        analog_scan_chain_write();
+        analog_scan_chain_load();
+    }
+
+    // Debugging output
+    // 1.1V/VDDD tap fix
+    // The print is now broken down into 3 statements instead of one big
+    // print statement
+    // doing this prevent a long string of loads back to back
+    printf("HF=%d-%d   2M=%d-%d", count_HFclock, HF_CLOCK_fine, count_2M,
+           RC2M_coarse);
+    printf(",%d,%d   LC=%d-%d   ", RC2M_fine, RC2M_superfine, count_LC,
+           synclight_cal_vars.LC_code);
+    printf("IF=%d-%d\r\n", count_IF, IF_fine);
+
+    if (synclight_cal_vars.optical_cal_iteration >= 25 &&
+        (!synclight_cal_vars.optical_LC_cal_enable ||
+         synclight_cal_vars.optical_LC_cal_finished)) {
+        // Disable this ISR
+        ICER = 0x1800;
+        synclight_cal_vars.optical_cal_iteration = 0;
+        synclight_cal_vars.optical_cal_finished = 1;
+
+        // Store the last count values
+        synclight_cal_vars.num_32k_ticks_in_100ms = count_32k;
+        synclight_cal_vars.num_2MRC_ticks_in_100ms = count_2M;
+        synclight_cal_vars.num_IFclk_ticks_in_100ms = count_IF;
+        synclight_cal_vars.num_LC_ch11_ticks_in_100ms = count_LC;
+        synclight_cal_vars.num_HFclock_ticks_in_100ms = count_HFclock;
+
+        // Debug prints
+        // printf("LC_code=%d\r\n", synclight_cal_vars.LC_code);
+        // printf("IF_fine=%d\r\n", IF_fine);
+
+        // This was an earlier attempt to build out a complete table of
+        // LC_code for TX/RX on each channel It doesn't really work well
+        // yet so leave it commented printf("Building channel
+        // table...");
+
+        // radio_build_channel_table(LC_code);
+
+        // printf("done\r\n");
+
+        // radio_disable_all();
+
+        // Halt all counters
+        ANALOG_CFG_REG__0 = 0x0000;
+    }
+}
 // this function use to test call calibration frenquency, so just some print.
 // use this in decode_lighthouse #600
 void sync_light_calibrate_isr_placeholder(void) {

--- a/scm_v3c/calibrate_interrupt.c
+++ b/scm_v3c/calibrate_interrupt.c
@@ -424,7 +424,8 @@ void sync_light_calibrate_isr(void) {
     }
 }
 
-void sync_light_calibrate_isr_individual_LC(uint32_t LC_start, uint32_t LC_end) {
+void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
+                                     uint32_t count_IF, uint32_t count_LC) {
     //	gpio_10_toggle();
 
     // This interrupt goes off when the optical register holds the value {221,
@@ -440,8 +441,7 @@ void sync_light_calibrate_isr_individual_LC(uint32_t LC_start, uint32_t LC_end) 
 
     //    int32_t t;
     uint32_t rdata_lsb, rdata_msb;
-    int32_t count_LC;
-    uint32_t count_32k, count_2M, count_HFclock, count_IF;
+    uint32_t count_32k;
     // a new LC_diff to replace the struct variable one
     // (synclight_cal_vars.cal_LC_diff).
     int32_t real_LC_diff;
@@ -465,42 +465,35 @@ void sync_light_calibrate_isr_individual_LC(uint32_t LC_start, uint32_t LC_end) 
     IF_coarse = scm3c_hw_interface_get_IF_coarse();
     IF_fine = scm3c_hw_interface_get_IF_fine();
 
-    // Disable all counters
-    ANALOG_CFG_REG__0 = 0x007F;
-
     // Keep track of how many calibration iterations have been completed
     synclight_cal_vars.optical_cal_iteration++;
 
-    // Read 32k counter
-    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x000000);
-    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x040000);
-    count_32k = rdata_lsb + (rdata_msb << 16);
+    // // Read 32k counter
+    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x000000);
+    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x040000);
+    // count_32k = rdata_lsb + (rdata_msb << 16);
 
-    // Read HF_CLOCK counter
-    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x100000);
-    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x140000);
-    count_HFclock = rdata_lsb + (rdata_msb << 16);
+    // // Read HF_CLOCK counter
+    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x100000);
+    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x140000);
+    // count_HFclock = rdata_lsb + (rdata_msb << 16);
 
-    // Read 2M counter
-    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x180000);
-    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x1C0000);
-    count_2M = rdata_lsb + (rdata_msb << 16);
+    // // Read 2M counter
+    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x180000);
+    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x1C0000);
+    // count_2M = rdata_lsb + (rdata_msb << 16);
 
-    // Read LC_div counter (via counter4)
-    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x280000);
-    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x2C0000);
-    count_LC = rdata_lsb + (rdata_msb << 16);
+    // // Read LC_div counter (via counter4)
+    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x280000);
+    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x2C0000);
+    // count_LC = rdata_lsb + (rdata_msb << 16);
 
-    // Read IF ADC_CLK counter
-    rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x300000);
-    rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x340000);
-    count_IF = rdata_lsb + (rdata_msb << 16);
+    // // Read IF ADC_CLK counter
+    // rdata_lsb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x300000);
+    // rdata_msb = *(unsigned int*)(APB_ANALOG_CFG_BASE + 0x340000);
+    // count_IF = rdata_lsb + (rdata_msb << 16);
 
-    // Reset all counters
-    ANALOG_CFG_REG__0 = 0x0000;
-
-    // Enable all counters
-    ANALOG_CFG_REG__0 = 0x3FFF;
+    printf("run in sync cal\r\n");
 
     // Don't make updates on the first two executions of this ISR
     if (synclight_cal_vars.optical_cal_iteration > 2) {

--- a/scm_v3c/calibrate_interrupt.c
+++ b/scm_v3c/calibrate_interrupt.c
@@ -464,7 +464,7 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
     // Keep track of how many calibration iterations have been completed
     synclight_cal_vars.optical_cal_iteration++;
 
-    printf("run in sync cal\r\n");
+    // printf("run in sync cal\r\n"); // for debug
 
     // Don't make updates on the first two executions of this ISR
     if (synclight_cal_vars.optical_cal_iteration > 2) {
@@ -504,10 +504,6 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
 
         synclight_cal_vars.optical_LC_cal_enable = 1;  // just test
 
-        //    disable it to reduce time cost
-        printf("condition in %u, %u, diff:%u\r\n",
-               synclight_cal_vars.optical_LC_cal_enable,
-               synclight_cal_vars.optical_LC_cal_finished, real_LC_diff);
 
         if (synclight_cal_vars.optical_LC_cal_enable &&
             (!synclight_cal_vars.optical_LC_cal_finished)) {
@@ -516,14 +512,15 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
             synclight_cal_vars.LC_mid = synclight_cal_vars.cal_LC_mid;
             synclight_cal_vars.LC_fine = synclight_cal_vars.cal_LC_fine;
 
-            printf("count_LC: %u, LC_target: %u, LC_diff: %u\r\n", count_LC,
+            printf("Start: Count_LC: %u, LC_target: %u, Diff: %u\r\n", count_LC,
                    synclight_cal_vars.LC_target, real_LC_diff);
 
             // By moving this print, time cost 133-125ms, but I need this
             // info...so reduce synclight count to 7
-            printf("coarse: %u, mid: %u, fine: %u\n",
+            printf("Coarse: %u, Mid: %u, Fine: %u\n",
                    synclight_cal_vars.LC_coarse, synclight_cal_vars.LC_mid,
                    synclight_cal_vars.LC_fine);
+
             // why the stop codition is not related to LC_diff? I find
             // that the mid is correct enought when LC_diff is smaller
             // than 100.
@@ -639,23 +636,23 @@ void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M,
         synclight_cal_vars.num_LC_ch11_ticks_in_100ms = count_LC;
         synclight_cal_vars.num_HFclock_ticks_in_100ms = count_HFclock;
 
-        // Debug prints
-        // printf("LC_code=%d\r\n", synclight_cal_vars.LC_code);
-        // printf("IF_fine=%d\r\n", IF_fine);
-
-        // This was an earlier attempt to build out a complete table of
-        // LC_code for TX/RX on each channel It doesn't really work well
-        // yet so leave it commented printf("Building channel
-        // table...");
-
-        // radio_build_channel_table(LC_code);
-
-        // printf("done\r\n");
-
         // radio_disable_all();
 
         // Halt all counters
         // ANALOG_CFG_REG__0 = 0x0000;
+
+        // give final LC parameters to optimal value
+        synclight_cal_vars.LC_coarse_opt = synclight_cal_vars.LC_coarse;
+        synclight_cal_vars.LC_mid_opt = synclight_cal_vars.LC_mid;
+        synclight_cal_vars.LC_fine_opt = synclight_cal_vars.LC_fine;
+
+        // all calibrate completed, print feedback
+        printf("All calibrate completed\r\n"); 
+
+        // print final optimal LC coarse/mid/fine
+        printf("Final optimal LC coarse/mid/fine: %u, %u, %u\r\n",
+               synclight_cal_vars.LC_coarse_opt, synclight_cal_vars.LC_mid_opt,
+               synclight_cal_vars.LC_fine_opt);
     }
 }
 // this function use to test call calibration frenquency, so just some print.

--- a/scm_v3c/calibrate_interrupt.h
+++ b/scm_v3c/calibrate_interrupt.h
@@ -39,6 +39,10 @@ typedef struct {
     uint8_t LC_coarse;
     uint8_t LC_mid;
     uint8_t LC_fine;
+    // the optimal LC parameters
+    uint8_t LC_coarse_opt;
+    uint8_t LC_mid_opt;
+    uint8_t LC_fine_opt;
 } synclight_calibrate_vars_t;
 //=========================== prototypes ======================================
 

--- a/scm_v3c/calibrate_interrupt.h
+++ b/scm_v3c/calibrate_interrupt.h
@@ -65,6 +65,7 @@ void gpio_ext_10_interrupt_enable(void);
 void gpio_ext_10_interrupt_disable(void);
 void sync_light_calibrate_init(void);
 void sync_light_calibrate_isr(void);
+void sync_light_calibrate_isr_individual_LC(uint32_t LC_start, uint32_t LC_end);
 void sync_light_calibrate_isr_placeholder(void);
 
 //=========================== private =========================================

--- a/scm_v3c/calibrate_interrupt.h
+++ b/scm_v3c/calibrate_interrupt.h
@@ -14,7 +14,7 @@
 #define LC_CAL_MID_MAX 31
 #define LC_CAL_FINE_MIN 15
 #define LC_CAL_FINE_MAX 15
-#define MIN_LC_DIFF 2500
+#define MIN_LC_DIFF 100
 //=========================== variables =======================================
 typedef struct {
     uint8_t optical_cal_iteration;
@@ -65,7 +65,7 @@ void gpio_ext_10_interrupt_enable(void);
 void gpio_ext_10_interrupt_disable(void);
 void sync_light_calibrate_init(void);
 void sync_light_calibrate_isr(void);
-void sync_light_calibrate_isr_individual_LC(uint32_t LC_start, uint32_t LC_end);
+void sync_light_calibrate_all_clocks(uint32_t count_HFclock, uint32_t count_2M, uint32_t count_IF, uint32_t count_LC);
 void sync_light_calibrate_isr_placeholder(void);
 
 //=========================== private =========================================


### PR DESCRIPTION
1.Give value to  LC_coarse_opt, LC_mid_opt, LC_fine_opt; then the next state can just use the parameters without running calibration again.

2. the boundary need modified to find a stable calibration period, since a 60us wave will be shorter in while () read.